### PR TITLE
Avoid parsing wrong formatted dates at the end of string

### DIFF
--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -103,7 +103,7 @@ module Hashme
         typecast_hash_to_date(value)
       elsif value.is_a?(Time) # sometimes people think date is time!
         value.to_date
-      elsif value.to_s =~ /(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z/
+      elsif value.to_s =~ /\A(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z/
         # Faster than parsing the date
         Date.new($1.to_i, $2.to_i, $3.to_i)
       else

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -103,7 +103,7 @@ module Hashme
         typecast_hash_to_date(value)
       elsif value.is_a?(Time) # sometimes people think date is time!
         value.to_date
-      elsif value.to_s =~ /\A(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z/
+      elsif value.to_s =~ /ˆ\A(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z$/
         # Faster than parsing the date
         Date.new($1.to_i, $2.to_i, $3.to_i)
       else

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -103,7 +103,7 @@ module Hashme
         typecast_hash_to_date(value)
       elsif value.is_a?(Time) # sometimes people think date is time!
         value.to_date
-      elsif value.to_s =~ /ˆ\A(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z$/
+      elsif value.to_s =~ /ˆ(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})$/
         # Faster than parsing the date
         Date.new($1.to_i, $2.to_i, $3.to_i)
       else

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -103,7 +103,7 @@ module Hashme
         typecast_hash_to_date(value)
       elsif value.is_a?(Time) # sometimes people think date is time!
         value.to_date
-      elsif value.to_s =~ /(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})/
+      elsif value.to_s =~ /(\d{4})[\-|\/](\d{2})[\-|\/](\d{2})\z/
         # Faster than parsing the date
         Date.new($1.to_i, $2.to_i, $3.to_i)
       else

--- a/spec/hashme/property_casting_spec.rb
+++ b/spec/hashme/property_casting_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class Course
   include Hashme
-  
+
   property :title, String
   property :participants, [Object]
   property :ends_at, Time
@@ -506,6 +506,11 @@ describe Hashme::PropertyCasting do
         expect(course.started_on.month).to eql(12)
         expect(course.started_on.day).to eql(20)
         expect(course.started_on.year).to eql(2006)
+      end
+
+      it 'does not typecast wrongly formatted dates (ensure consider the end of string)' do
+        course.started_on = '2016-10-030'
+        expect(course['started_on']).to be_nil
       end
     end
 

--- a/spec/hashme/property_casting_spec.rb
+++ b/spec/hashme/property_casting_spec.rb
@@ -508,6 +508,13 @@ describe Hashme::PropertyCasting do
         expect(course.started_on.year).to eql(2006)
       end
 
+      it 'parses date with wrong formatted year (ensure consider the beginning of string)' do
+        course.started_on = 'abc02016-10-03'
+        expect(course['started_on'].month).to eql(10)
+        expect(course['started_on'].day).to eql(03)
+        expect(course['started_on'].year).to eql(2016)
+      end
+
       it 'does not typecast wrongly formatted dates (ensure consider the end of string)' do
         course.started_on = '2016-10-030'
         expect(course['started_on']).to be_nil


### PR DESCRIPTION
**Summary**

When typecasts an `String` value to a `Date` and `typecast_to_date` method receives a wrongly formatted string, such as _'2016-09-030'_ I think the end of string should be considered in regular expression, by this way we'll be able to recognize an error instead of infer a possible wrong date.
