### PR TITLE
Support Proc type as property default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ u.errors.first     # [:email, "can't be blank"]
 ### 0.2.6 - pending
 
  * Setting ActiveModel minimum to 4.0, adding travis config to test both 4.0 and 5.0. (@samlown)
+ * Adding support for using `Proc` type as default values for properties
 
 ### 0.2.5 - 2016-06-03 - Again!
 

--- a/lib/hashme/property.rb
+++ b/lib/hashme/property.rb
@@ -1,7 +1,7 @@
 module Hashme
   class Property
 
-    attr_reader :name, :type, :default, :array
+    attr_reader :name, :type, :array
 
     def initialize(name, type, opts = {})
       @name = name.to_sym
@@ -25,6 +25,11 @@ module Hashme
 
     def to_sym
       name
+    end
+
+    def default
+      return @default.call if @default.is_a?(Proc)
+      @default
     end
 
     # Build a new object of the type defined by the property.

--- a/spec/hashme/property_spec.rb
+++ b/spec/hashme/property_spec.rb
@@ -36,6 +36,11 @@ describe Hashme::Property do
       prop = subject.new(:name, String, :default => "Freddo")
       expect(prop.default).to eql("Freddo")
     end
+
+    it "should accept a default option from a Proc" do
+      prop = subject.new(:name, String, :default => -> { "Freddo" })
+      expect(prop.default).to eql("Freddo")
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
Thanks to that we can apply this pattern:
```
class Model
  include Hashme
  property :created_at, DateTime, default: -> { DateTime.now }
end
```

This works because the main module initializer invokes the `set_defaults`, that in turn populate the properties with the result from `default` method in `Attribute`. 
