### PR TITLE
Several enhancements

### DIFF
--- a/lib/hashme.rb
+++ b/lib/hashme.rb
@@ -2,6 +2,8 @@ require "hashme/version"
 
 # External dependencies
 
+require "uri"
+
 require "active_model"
 require "active_model/naming"
 require "active_model/serialization"

--- a/lib/hashme/properties.rb
+++ b/lib/hashme/properties.rb
@@ -68,7 +68,7 @@ module Hashme
       def define_property_methods(property)
         # Getter
         define_method(property.name) do
-          get_attribute(property.name) || property.default
+          get_attribute(property.name)
         end
         # Setter
         define_method "#{property.name}=" do |value|

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -1,5 +1,8 @@
 module Hashme
 
+  # Alias TrueClass as Boolean, so that it can be used as property types
+  Boolean = TrueClass
+
   # Special property casting for reveiving data from sources without Ruby types, such as query
   # parameters from an API or JSON documents.
   #

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -7,7 +7,7 @@ module Hashme
   module PropertyCasting
     extend self
 
-    CASTABLE_TYPES = [String, Symbol, TrueClass, Integer, Float, BigDecimal, DateTime, Time, Date, Class]
+    CASTABLE_TYPES = [String, Symbol, TrueClass, Integer, Float, BigDecimal, DateTime, Time, Date, Class, URI]
 
     # Automatically typecast the provided value into an instance of the provided type.
     def cast(property, owner, value)
@@ -183,6 +183,13 @@ module Hashme
     def typecast_to_class(value)
       value.to_s.constantize
     rescue NameError
+      nil
+    end
+
+    # Typecast a value to URI
+    def typecast_to_uri(value)
+      URI(value)
+    rescue ArgumentError
       nil
     end
 

--- a/spec/hashme/properties_spec.rb
+++ b/spec/hashme/properties_spec.rb
@@ -117,6 +117,12 @@ describe Hashme::Properties do
       expect(obj.nickname).to be_nil
     end
 
+    it 'should not return the default value when a Boolean is set to false' do
+      model.property :flag, TrueClass, :default => true
+      obj.flag = false
+      expect(obj.flag).to be(false)
+    end
+
     it "should create helper method with support for default values" do
       model.property :name, String, :default => "Sam"
       expect(obj.name).to eql("Sam")

--- a/spec/hashme/property_casting_spec.rb
+++ b/spec/hashme/property_casting_spec.rb
@@ -603,14 +603,14 @@ describe Hashme::PropertyCasting do
     [ true, 'true', 'TRUE', '1', 1, 't', 'T' ].each do |value|
       it "returns true when value is #{value.inspect}" do
         course.active = value
-        expect(course['active']).to be_truthy
+        expect(course['active']).to be(true)
       end
     end
 
     [ false, 'false', 'FALSE', '0', 0, 'f', 'F' ].each do |value|
       it "returns false when value is #{value.inspect}" do
         course.active = value
-        expect(course['active']).to be_falsey
+        expect(course['active']).to be(false)
       end
     end
 

--- a/spec/hashme/property_casting_spec.rb
+++ b/spec/hashme/property_casting_spec.rb
@@ -12,7 +12,7 @@ class Course
   property :started_on, Date
   property :updated_at, DateTime
   property :active, TrueClass
-  property :very_active, TrueClass
+  property :very_active, Boolean
   property :klass, Class
   property :currency, String, :default => 'EUR'
   property :symbol, Symbol
@@ -599,7 +599,7 @@ describe Hashme::PropertyCasting do
     end
   end
 
-  describe 'when type primitive is a Boolean' do
+  describe 'when type primitive is a TrueClass' do
 
     [ true, 'true', 'TRUE', '1', 1, 't', 'T' ].each do |value|
       it "returns true when value is #{value.inspect}" do
@@ -621,6 +621,12 @@ describe Hashme::PropertyCasting do
         expect(course['active']).to be_nil
       end
     end
+
+    it "supports Boolean as an alias of TrueClass" do
+      course.very_active = 't'
+      expect(course['very_active']).to be(true)
+    end
+
   end
 
   describe 'when type primitive is an URI' do

--- a/spec/hashme/property_casting_spec.rb
+++ b/spec/hashme/property_casting_spec.rb
@@ -16,6 +16,7 @@ class Course
   property :klass, Class
   property :currency, String, :default => 'EUR'
   property :symbol, Symbol
+  property :uri, URI
 end
 
 describe Hashme::PropertyCasting do
@@ -619,6 +620,24 @@ describe Hashme::PropertyCasting do
         course.active = value
         expect(course['active']).to be_nil
       end
+    end
+  end
+
+  describe 'when type primitive is an URI' do
+    it 'returns same value if an uri' do
+      value = URI('https://invopop.com')
+      course.uri = value
+      expect(course['uri']).to equal(value)
+    end
+
+    it 'returns an URI if parses as one' do
+      course.uri = 'https://invopop.com'
+      expect(course['uri']).to eql(URI('https://invopop.com'))
+    end
+
+    it 'does not typecast non-uri values' do
+      course.uri = 1234
+      expect(course['uri']).to be_nil
     end
   end
 end


### PR DESCRIPTION
* Fixes an issue causing booleans to return the default value (typically nil, but it could be `true`) when they are explicitly set to `false`.
* Adds support for `URI` properties with typecasting
* Adds an alias of `TrueClass` called `Boolean` to make boolean properties declaration more meaningful.
* Each enhancement is in a different commit.
* Originally implemented in`gobl.ruby` as [an extension](https://github.com/invopop/gobl.ruby/blob/76acb15ae566d79f324fef065df42dde896a2d42/lib/ext/hashme.rb)