### PR TITLE
Revamped casted array

### DIFF
--- a/lib/hashme/casted_array.rb
+++ b/lib/hashme/casted_array.rb
@@ -3,11 +3,7 @@ require 'forwardable'
 module Hashme
 
   # The Hashme CastedArray is a special object wrapper that allows other Model's
-  # or Objects to be stored in an array, but maintain casted ownership.
-  #
-  # Adding objects will automatically assign the Array's owner, as opposed
-  # to the array itself.
-  #
+  # or Objects to be stored in an array, but maintaining typecasting.
   class CastedArray
     extend Forwardable
 
@@ -21,7 +17,7 @@ module Hashme
       :encode_json, :as_json, :to_json,
       :inspect, :any?
 
-    def initialize(property, owner, values = [])
+    def initialize(property, values = [])
       @_array = []
       @property = property
       if values.respond_to?(:each)
@@ -54,7 +50,7 @@ module Hashme
     protected
 
     def instantiate_and_build(obj)
-      property.build(self, obj)
+      property.build(obj)
     end
 
   end

--- a/lib/hashme/properties.rb
+++ b/lib/hashme/properties.rb
@@ -14,7 +14,7 @@ module Hashme
     def set_attribute(name, value)
       property = get_property(name)
       if property
-        value = property.build(self, value)
+        value = property.build(value)
         if value.nil?
           delete(property.name)
         else

--- a/lib/hashme/property.rb
+++ b/lib/hashme/property.rb
@@ -33,11 +33,11 @@ module Hashme
     end
 
     # Build a new object of the type defined by the property.
-    def build(owner, value)
+    def build(value)
       if array && value.is_a?(Array)
-        CastedArray.new(self, owner, value)
+        CastedArray.new(self, value)
       else
-        PropertyCasting.cast(self, owner, value)
+        PropertyCasting.cast(self, value)
       end
     end
 

--- a/lib/hashme/property_casting.rb
+++ b/lib/hashme/property_casting.rb
@@ -10,7 +10,7 @@ module Hashme
     CASTABLE_TYPES = [String, Symbol, TrueClass, Integer, Float, BigDecimal, DateTime, Time, Date, Class]
 
     # Automatically typecast the provided value into an instance of the provided type.
-    def cast(property, owner, value)
+    def cast(property, value)
       return nil if value.nil?
       type = property.type
       if value.instance_of?(type) || type == Object

--- a/spec/hashme/casted_array_spec.rb
+++ b/spec/hashme/casted_array_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Hashme::CastedArray do
-  let :owner do
-    double()
-  end
-
   let :submodel do
     Class.new do
       include Hashme
@@ -17,7 +13,7 @@ describe Hashme::CastedArray do
   end
 
   subject do
-    Hashme::CastedArray.new(property, owner, [{:name => 'test'}])
+    Hashme::CastedArray.new(property, [{:name => 'test'}])
   end
 
   describe "#initialize" do

--- a/spec/hashme/casted_array_spec.rb
+++ b/spec/hashme/casted_array_spec.rb
@@ -36,4 +36,96 @@ describe Hashme::CastedArray do
     expect(subject.last.class).to eql(submodel)
     expect(subject.last.name).to eql('test2')
   end
+
+  it "should cast items using `push`" do
+    subject.push({ :name => 'test2'}, { :name => 'test3' })
+    expect(subject.last.class).to eql(submodel)
+    expect(subject.last.name).to eql('test3')
+  end
+
+  it "should cast items using `concat`" do
+    subject.concat([{ :name => 'test2'}], [{ :name => 'test3' }])
+    expect(subject.last.class).to eql(submodel)
+    expect(subject.last.name).to eql('test3')
+  end
+
+  it "should cast items using `insert`" do
+    subject.insert(0, { :name => 'test2'}, { :name => 'test3' })
+    expect(subject[1].class).to eql(submodel)
+    expect(subject[1].name).to eql('test3')
+  end
+
+  it "should cast items using `unshift`" do
+    subject.unshift({ :name => 'test2'}, { :name => 'test3' })
+    expect(subject[1].class).to eql(submodel)
+    expect(subject[1].name).to eql('test3')
+  end
+
+  it "should cast items using `replace`" do
+    subject.replace([{ :name => 'test2'}, { :name => 'test3' }])
+    expect(subject[1].class).to eql(submodel)
+    expect(subject[1].name).to eql('test3')
+  end
+
+  it "should cast items using `[]=`" do
+    subject[5, 10] = { :name => 'test2'}
+    expect(subject[5].class).to eql(submodel)
+    expect(subject[5].name).to eql('test2')
+  end
+
+  it "should cast items using fill with block" do
+    subject.fill(0) { |index| { :name => "test#{index}" } }
+    expect(subject.last.class).to eql(submodel)
+    expect(subject.last.name).to eql('test0')
+  end
+
+  it "should cast items using fill without block" do
+    subject.fill({ :name => "test-filled" }, 0)
+    expect(subject.last.class).to eql(submodel)
+    expect(subject.last.name).to eql('test-filled')
+  end
+
+  it "should cast items using `collect!` with a block" do
+    subject.collect! { |item| { :name => "Mapped #{item.name}" } }
+    expect(subject.first.name).to eql('Mapped test')
+  end
+
+  it "should support Enumerable methods" do
+    map = subject.map(&:name)
+    expect(map).to be_an(Enumerable)
+    expect(map.first).to eql('test')
+  end
+
+  it "should compare for equality with CastedArrays" do
+    same = Hashme::CastedArray.new(property, [{:name => 'test'}])
+    different = Hashme::CastedArray.new(property, [{:name => 'test2'}])
+
+    expect(subject == same).to be(true)
+    expect(subject.eql?(same)).to be(true)
+
+    expect(subject == different).to be(false)
+    expect(subject.eql?(different)).to be(false)
+  end
+
+  it "should compare for equality with Arrays" do
+    same = [submodel.new(:name => 'test')]
+    different = [submodel.new(:name => 'test2')]
+
+    expect(subject == same).to be(true)
+    expect(subject.eql?(same)).to be(true)
+
+    expect(subject == different).to be(false)
+    expect(subject.eql?(different)).to be(false)
+  end
+
+  it "should be compared for equality with Arrays" do
+    same = [submodel.new(:name => 'test')]
+    different = [submodel.new(:name => 'test2')]
+
+    expect(same == subject).to be(true)
+    expect(same.eql?(subject)).to be(true)
+
+    expect(different == same).to be(false)
+    expect(different.eql?(same)).to be(false)
+  end
 end

--- a/spec/hashme/casted_array_spec.rb
+++ b/spec/hashme/casted_array_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Hashme::CastedArray do
-
   let :owner do
     double()
   end
@@ -13,43 +12,32 @@ describe Hashme::CastedArray do
     end
   end
 
-  describe "#initialize" do
-    let :property do
-      Hashme::Property.new(:name, String)
-    end
-    before :each do
-      @obj = Hashme::CastedArray.new(property, owner, ['test'])
-    end
+  let :property do
+    Hashme::Property.new(:item, submodel)
+  end
 
+  subject do
+    Hashme::CastedArray.new(property, owner, [{:name => 'test'}])
+  end
+
+  describe "#initialize" do
     it "should prepare array" do
-      expect(@obj.length).to eql(1)
+      expect(subject.length).to eql(1)
     end
 
     it "should set property" do
-      expect(@obj.property).to eql(property)
+      expect(subject.property).to eql(property)
     end
 
     it "should instantiate and cast each value" do
-      expect(@obj.first).to eql("test")
-      expect(@obj.first.class).to eql(String)
-    end
-  end
-
-  describe "adding to array" do
-    subject do
-      Hashme::CastedArray.new(property, owner, [{:name => 'test'}])
-    end
-    let :property do
-      Hashme::Property.new(:item, submodel)
-    end
-
-    it "should cast new items" do
-      subject << {:name => 'test2'}
-      expect(subject.last.class).to eql(submodel)
+      expect(subject.first.class).to eql(submodel)
       expect(subject.first.name).to eql('test')
-      expect(subject.last.name).to eql('test2')
     end
-
   end
 
+  it "should cast items added to the array" do
+    subject << {:name => 'test2'}
+    expect(subject.last.class).to eql(submodel)
+    expect(subject.last.name).to eql('test2')
+  end
 end

--- a/spec/hashme/properties_spec.rb
+++ b/spec/hashme/properties_spec.rb
@@ -39,7 +39,7 @@ describe Hashme::Properties do
     it "should set and cast attribute with property" do
       property = model.send(:properties)[:name]
       name = "Fred Flinstone"
-      expect(property).to receive(:build).with(obj, name).and_return(name)
+      expect(property).to receive(:build).with(name).and_return(name)
       obj.set_attribute(:name, name)
       expect(obj[:name]).to eql(name)
     end

--- a/spec/hashme/property_spec.rb
+++ b/spec/hashme/property_spec.rb
@@ -6,10 +6,6 @@ describe Hashme::Property do
     described_class
   end
 
-  let :owner do
-    double()
-  end
-
   let :submodel do
     Class.new do
       include Hashme
@@ -61,7 +57,7 @@ describe Hashme::Property do
     context "without an array" do
       it "should build a new object" do
         prop = subject.new(:date, Time)
-        obj = prop.build(owner, "2013-06-02T12:00:00Z")
+        obj = prop.build("2013-06-02T12:00:00Z")
         expect(obj.class).to eql(Time)
         expect(obj).to eql(Time.utc(2013, 6, 2, 12, 0, 0))
       end
@@ -70,13 +66,13 @@ describe Hashme::Property do
     context "with an array" do
       it "should convert regular array to casted array" do
         prop = subject.new(:dates, [Time])
-        obj = prop.build(owner, ["2013-06-02T12:00:00"])
+        obj = prop.build(["2013-06-02T12:00:00"])
         expect(obj.class).to eql(Hashme::CastedArray)
         expect(obj.first.class).to eql(Time)
       end
       it "should handle complex objects" do
         prop = subject.new(:items, [submodel])
-        obj = prop.build(owner, [{:name => 'test'}])
+        obj = prop.build([{:name => 'test'}])
         expect(obj.class).to eql(Hashme::CastedArray)
         expect(obj.first.class).to eql(submodel)
         expect(obj.first.name).to eql('test')


### PR DESCRIPTION
* While using `hashme`, I kept coming across scenarios where I was missing `CastedArray` to behave like an `Array`. For example, [here](https://github.com/invopop/gobl.ruby/blob/76acb15ae566d79f324fef065df42dde896a2d42/lib/ext/hashme.rb#L21), [here](https://github.com/invopop/gobl.ruby/blob/76acb15ae566d79f324fef065df42dde896a2d42/lib/ext/hashme.rb#L24) and [here](https://github.com/invopop/plemsi/blob/c7d521d19565babf6bcd758855bf8a35b8ee40c3/app/domain/envelope_patcher.rb#L36) I had to implement workarounds for this reason.
* This PR reimplements `CastedArray` inheriting directly from `Array` and overriding any method that allows to add or replace array items to ensure they are typecasted. This provides users of the library with the full `Array` API. The class is now fully tested too.
* I also removed the remnants of the seemingly no longer used `owner` parameter.
* @samlown as this is an implementation that you may have considered (and, perhaps, discarded) in the past, your thoughts here will be particularly appreciated.
* Final word to give credit to ChatGPT for [her help](https://user-images.githubusercontent.com/856/212327103-179d811e-16fb-4ed7-b27c-01891506a58f.png) with [the implementation](https://user-images.githubusercontent.com/856/212327113-f0078940-a96b-4bed-9609-9d69907364b4.png). Scary!